### PR TITLE
Changed con.start() to con.run(), 

### DIFF
--- a/notes_examples/chapter8/ThreadedServer.java
+++ b/notes_examples/chapter8/ThreadedServer.java
@@ -45,7 +45,7 @@ public class ThreadedServer
             }	
             
             ThreadedConnectionHandler con = new ThreadedConnectionHandler(clientSocket);
-            con.start(); 
+            con.run(); 
             System.out.println("02. -- Finished communicating with client:" + clientSocket.getInetAddress().toString());
         }
         // Server is no longer listening for client connections - time to shut down.


### PR DESCRIPTION
ThreadedConnectionHandler has no `start()`, method from context I've inferred that ThreadedServer means to call the `run()`
method instead.